### PR TITLE
Troca de prioridade de inserção de descrição

### DIFF
--- a/lib/main.php
+++ b/lib/main.php
@@ -119,10 +119,10 @@ XML;
       }
 
       // text description
-      if (isset($body['body_text'])) {
-        $entry['description'] = $body['body_text'];
-      } else if (isset($body['body_html'])) {
+      if (isset($body['body_html'])) {
         $entry['description'] = strip_tags($body['body_html']);
+      } else if (isset($body['body_text'])) {
+        $entry['description'] = $body['body_text'];
       }
 
       // product page links

--- a/lib/main.php
+++ b/lib/main.php
@@ -121,7 +121,7 @@ XML;
       // text description
       if (isset($body['body_html'])) {
         $entry['description'] = strip_tags($body['body_html']);
-      } else if (isset($body['body_text'])) {
+      } else if (isset($body['body_text']) && !empty($body['body_text'])) {
         $entry['description'] = $body['body_text'];
       }
 


### PR DESCRIPTION
Como o body_html normalmente possui mais informações que ajudam na venda, sugiro colocar o body_html como prioridade, até porque é esse campo que possui no painel dentro de produtos.