### PR TITLE
chore: add query string builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ https://storefront.e-com.plus/products-feed.xml?store_id={storeId}&domain={domai
 
 ### Additional examples
 
-> Set query string
-
-```
-https://storefront.e-com.plus/products-feed.xml?store_id={storeId}&domain={domain}&qs={"utm_campaign":"facebook_ads"}
-```
-
 > Forcing `google_product_category_id`
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ https://storefront.e-com.plus/products-feed.xml?store_id={storeId}&domain={domai
 
 ### Additional examples
 
+> Set query string
+
+```
+https://storefront.e-com.plus/products-feed.xml?store_id={storeId}&domain={domain}&qs={"utm_campaign":"facebook_ads"}
+```
+
 > Forcing `google_product_category_id`
 
 ```

--- a/index.php
+++ b/index.php
@@ -73,6 +73,10 @@ $discount = isset($_GET['discount']) && (float)$_GET['discount'] > 0
   ? (float)$_GET['discount']
   : 0;
 
+$query_string = isset($_GET['query_string'])
+  ? strval($_GET['query_string'])
+  : null;
+
 $output_file = null;
 $wip_output_file = null;
 
@@ -120,7 +124,7 @@ $products_feed = new ProductsFeed(
 
 $xml = $products_feed->xml(
   !$is_list_all ? @$_GET['title'] : null,
-  !$is_list_all ? (@$_GET['query_string'] || @$_GET['qs']) : null,
+  $query_string,
   !$is_list_all && isset($_GET['set_properties']) ? json_decode($_GET['set_properties'], true) : null,
   $product_ids,
   $search_endpoint,

--- a/lib/main.php
+++ b/lib/main.php
@@ -153,18 +153,9 @@ XML;
       // https://support.google.com/merchants/answer/7052112?hl=en
       if (!$query_string) {
         // fix http query string
-        $query_string = [
-          "_" => "feed",
-        ];
-      }
-
-      function buildQuery ($url, $query_string) {
-        // Check if there are parameters to add
-        if (is_array($query_string)) {
-          $url .= '?' . http_build_query($query_string, '', '&amp;');
-          
-        }
-        return $url;
+        $query_string = '?_=feed';
+      } else if ($query_string[0] !== '?') {
+        $query_string = '?' . $query_string;
       }
 
       $entry = array(
@@ -192,12 +183,11 @@ XML;
 
       // product page links
       if (isset($body['permalink'])) {
-        $entry['link'] = buildQuery($body['permalink'], $query_string);
+        $entry['link'] = $body['permalink'] . $query_string;
       } else if (strpos($this->base_uri, '{{_id}}')) {
         $entry['link'] = str_replace('{{_id}}', $body['_id'], $this->base_uri);
       } else if (isset($body['slug'])) {
-        $entry['link'] = $this->base_uri . $body['slug'];
-        $entry['link'] = buildQuery($entry['link'], $query_string);
+        $entry['link'] = $this->base_uri . $body['slug'] . $query_string;
         if ($group_id) {
           $entry['link'] .= '&amp;variation_id=' . $body['_id'];
         }

--- a/lib/main.php
+++ b/lib/main.php
@@ -153,9 +153,18 @@ XML;
       // https://support.google.com/merchants/answer/7052112?hl=en
       if (!$query_string) {
         // fix http query string
-        $query_string = '?_=feed';
-      } else if ($query_string[0] !== '?') {
-        $query_string = '?' . $query_string;
+        $query_string = [
+          "_" => "feed",
+        ];
+      }
+
+      function buildQuery ($url, $query_string) {
+        // Check if there are parameters to add
+        if (is_array($query_string)) {
+          $url .= '?' . http_build_query($query_string, '', '&amp;');
+          
+        }
+        return $url;
       }
 
       $entry = array(
@@ -183,11 +192,12 @@ XML;
 
       // product page links
       if (isset($body['permalink'])) {
-        $entry['link'] = $body['permalink'] . $query_string;
+        $entry['link'] = buildQuery($body['permalink'], $query_string);
       } else if (strpos($this->base_uri, '{{_id}}')) {
         $entry['link'] = str_replace('{{_id}}', $body['_id'], $this->base_uri);
       } else if (isset($body['slug'])) {
-        $entry['link'] = $this->base_uri . $body['slug'] . $query_string;
+        $entry['link'] = $this->base_uri . $body['slug'];
+        $entry['link'] = buildQuery($entry['link'], $query_string);
         if ($group_id) {
           $entry['link'] .= '&amp;variation_id=' . $body['_id'];
         }


### PR DESCRIPTION
Currently, when we set:

query_string=utm_campaign%3DABC

URL:
https://storefront.e-com.plus/products-feed.xml?store_id=1032&domain=www.blowgummies.com.br&search_field=categories.slug&search_value=catalogo&skip_variations=true&query_string=utm_campaign%3DABC

We receive:
https://www.blowgummies.com.br/blow-gummies-60-dias-de-tratamento-uva?1

So, I suggest the following format:

https://storefront.e-com.plus/products-feed.xml?store_id=1032&domain=www.blowgummies.com.br&search_field=categories.slug&search_value=catalogo&skip_variations=true&query_string={"utm_campaign":"ABC"}

This will be processed within the `buildQuery` function to return the URL with the query string.



